### PR TITLE
Switch event to a union of all types

### DIFF
--- a/src/api/get_event.c
+++ b/src/api/get_event.c
@@ -17,14 +17,8 @@
 #include "plugins/core/core.h"
 
 
-int cci_get_event(cci_endpoint_t *endpoint, 
-                  cci_event_t ** const event,
-                  uint32_t flags)
+int cci_get_event(cci_endpoint_t *endpoint,
+                  cci_event_t ** const event)
 {
-    if (NULL == endpoint ||
-        NULL == event) {
-        return CCI_EINVAL;
-    }
-
-    return cci_core->get_event(endpoint, event, flags);
+    return cci_core->get_event(endpoint, event);
 }

--- a/src/api/return_event.c
+++ b/src/api/return_event.c
@@ -17,12 +17,7 @@
 #include "plugins/core/core.h"
 
 
-int cci_return_event(cci_endpoint_t *endpoint, cci_event_t *event)
+int cci_return_event(cci_event_t *event)
 {
-    if (NULL == endpoint ||
-        NULL == event) {
-        return CCI_EINVAL;
-    }
-
-    return cci_core->return_event(endpoint, event);
+    return cci_core->return_event(event);
 }

--- a/src/plugins/core/core.h
+++ b/src/plugins/core/core.h
@@ -63,10 +63,8 @@ typedef int (*cci_get_opt_fn_t)(cci_opt_handle_t *handle,
                                 cci_opt_name_t name, void** val, int *len);
 typedef int (*cci_arm_os_handle_fn_t)(cci_endpoint_t *endpoint, int flags);
 typedef int (*cci_get_event_fn_t)(cci_endpoint_t *endpoint,
-                                  cci_event_t ** const event,
-                                  uint32_t flags);
-typedef int (*cci_return_event_fn_t)(cci_endpoint_t *endpoint,
-                                     cci_event_t *event);
+                                  cci_event_t ** const event);
+typedef int (*cci_return_event_fn_t)(cci_event_t *event);
 typedef int (*cci_send_fn_t)(cci_connection_t *connection,
                              void *msg_ptr, uint32_t msg_len,
                              void *context, int flags);


### PR DESCRIPTION
To simplify the event, make it a union of all types. Each
event type has a unique struct. Each struct must start with
the event type.

This changed the header and core CCI files. It does not
update the drivers or tests.
