### PR TITLE
Add contexts to endpoint and connection

### DIFF
--- a/include/cci.h
+++ b/include/cci.h
@@ -492,7 +492,7 @@ typedef struct cci_endpoint {
       this URI. */
   char const * const name;
 
-  /*! Application specific context. */
+  /*! Application-provided, private context. */
   void *context;
 } cci_endpoint_t;
 
@@ -650,7 +650,7 @@ typedef struct cci_connection {
   cci_endpoint_t *endpoint;
   /*! Attributes of the connection */
   cci_conn_attribute_t attribute;
-  /*! Application specific context. */
+  /*! Application-provided, private context. */
   void *context;
 } cci_connection_t;
 


### PR DESCRIPTION
Allow application to set pointers to its own contexts
in the endpoint and connection. No need for the application
to maintain lists of conenctions (or endpoints).

This does not impact compiling or any current code.
