### PR TITLE
Add context parameter to cci_accept().

### DIFF
--- a/include/cci.h
+++ b/include/cci.h
@@ -4,6 +4,7 @@
  * Copyright (c) 2010-2011 Qlogic Corporation.  All rights reserved.
  * Copyright (c) 2010-2011 UT-Battelle, LLC.  All rights reserved.
  * Copyright (c) 2010-2011 Oak Ridge National Labs.  All rights reserved.
+ * Copyright © 2012 inria.  All rights reserved.
  *
  * See COPYING in top-level directory
  *
@@ -667,6 +668,8 @@ union cci_event;
 
   \param[in] conn_req		A connection request event previously returned by
 				cci_get_event().
+  \param[in] context		Cookie to be used to identify the connection in
+				incoming events.
   \param[in,out] connection	Connection pointer to a connection request structure.
 
   \return CCI_SUCCESS   The connection has been established.
@@ -680,6 +683,7 @@ union cci_event;
   \ingroup connection
 */
 CCI_DECLSPEC int cci_accept(union cci_event *conn_req,
+                            void *context,
                             cci_connection_t **connection);
 
 /*!
@@ -740,7 +744,8 @@ CCI_DECLSPEC int cci_reject(union cci_event *conn_req);
   \param[in] attribute	Attributes of the requested connection (reliability,
                         ordering, multicast, etc).
   \param[in] context	Cookie to be used to identify the completion through
-                        a connect accepted, rejected, or timedout event.
+                        a connect accepted, rejected, or timedout event, and
+                        used to identify the connection in incoming events.
   \param[in] flags      Currently unused.
   \param[in] timeout	NULL means forever.
 

--- a/src/api/accept.c
+++ b/src/api/accept.c
@@ -18,7 +18,8 @@
 
 
 int cci_accept(union cci_event *conn_req,
+               void *context,
                cci_connection_t **connection)
 {
-    return cci_core->accept(conn_req, connection);
+    return cci_core->accept(conn_req, context, connection);
 }

--- a/src/plugins/core/core.h
+++ b/src/plugins/core/core.h
@@ -40,6 +40,7 @@ typedef int (*cci_create_endpoint_fn_t)(cci_device_t *device,
                                         cci_os_handle_t *fd);
 typedef int (*cci_destroy_endpoint_fn_t)(cci_endpoint_t *endpoint);
 typedef int (*cci_accept_fn_t)(union cci_event *conn_req,
+                               void *context,
                                cci_connection_t **connection);
 typedef int (*cci_reject_fn_t)(union cci_event *conn_req);
 typedef int (*cci_connect_fn_t)(cci_endpoint_t *endpoint, char *server_uri,

--- a/src/plugins/core/gni/core_gni_api.c
+++ b/src/plugins/core/gni/core_gni_api.c
@@ -161,6 +161,7 @@ static int         gni_destroy_endpoint(
     cci_endpoint_t *            endpoint );
 static int         gni_accept(
     union cci_event *           conn_req,
+    void *                      context,
     cci_connection_t **         connection );
 static int         gni_reject(
     union cci_event *           conn_req );
@@ -1248,6 +1249,7 @@ static int gni_destroy_endpoint(  cci_endpoint_t *       endpoint ) {
 
 static int gni_accept(
     union cci_event *           event,
+    void *                      context,
     cci_connection_t **         connection ) {
 
     cci_device_t const *        device;
@@ -1292,6 +1294,7 @@ static int gni_accept(
 
     conn->tx_timeout=ep->tx_timeout;         // timeout presently unused
     conn->connection.endpoint=endpoint;
+    conn->connection.context=context;
     gconn->status=GNI_CONN_FAILED;
     gconn->conn=conn;                        // point back to conn
     conn->priv=gconn;

--- a/src/plugins/core/mx/core_mx_api.c
+++ b/src/plugins/core/mx/core_mx_api.c
@@ -30,7 +30,7 @@ static int mx_unbind(cci_service_t *service, cci_device_t *device);
 static int mx_get_conn_req(cci_service_t *service, 
                                  cci_conn_req_t **conn_req);
 static int mx_accept(cci_conn_req_t *conn_req, 
-                           cci_endpoint_t *endpoint, 
+                     void *context,
                            cci_connection_t **connection);
 static int mx_reject(cci_conn_req_t *conn_req);
 static int mx_connect(cci_endpoint_t *endpoint, char *server_uri, 
@@ -195,7 +195,7 @@ static int mx_get_conn_req(cci_service_t *service,
 
 
 static int mx_accept(cci_conn_req_t *conn_req, 
-                           cci_endpoint_t *endpoint, 
+                     void *context,
                            cci_connection_t **connection)
 {
     printf("In mx_accept\n");

--- a/src/plugins/core/portals/core_portals_api.c
+++ b/src/plugins/core/portals/core_portals_api.c
@@ -122,6 +122,7 @@ static int portals_create_endpoint(  cci_device_t         *device,
                                      cci_os_handle_t      *fd );
 static int portals_destroy_endpoint( cci_endpoint_t       *endpoint );
 static int portals_accept(           union cci_event      *event,
+                                     void                 *context,
                                      cci_connection_t     **connection );
 static int portals_reject(           union cci_event      *event );
 static int portals_connect(          cci_endpoint_t       *endpoint,
@@ -1175,6 +1176,7 @@ static int portals_destroy_endpoint(cci_endpoint_t *endpoint)
 
 static int portals_accept(
     union cci_event        *event,
+    void                   *context,
     cci_connection_t       **connection ) {
 
     int             ret;
@@ -1242,6 +1244,7 @@ static int portals_accept(
 
     conn->connection.attribute = event->request.attribute;
     conn->connection.endpoint = endpoint;
+    conn->connection.context = context;
     conn->connection.max_send_size = dev->device.max_send_size;
 
     pconn->idp = rx->pevent.initiator;

--- a/src/plugins/core/sock/core_sock_api.c
+++ b/src/plugins/core/sock/core_sock_api.c
@@ -53,6 +53,7 @@ static int sock_create_endpoint(cci_device_t *device,
                                     cci_os_handle_t *fd);
 static int sock_destroy_endpoint(cci_endpoint_t *endpoint);
 static int sock_accept(union cci_event *event,
+                       void *context,
                            cci_connection_t **connection);
 static int sock_reject(union cci_event *conn_req);
 static int sock_connect(cci_endpoint_t *endpoint, char *server_uri,
@@ -769,6 +770,7 @@ static uint8_t sock_ip_hash(in_addr_t ip, uint16_t port)
 }
 
 static int sock_accept(union cci_event *event,
+                       void *context,
                            cci_connection_t **connection)
 {
     uint8_t         a;
@@ -843,6 +845,7 @@ static int sock_accept(union cci_event *event,
 
     conn->connection.attribute = (enum cci_conn_attribute)a;
     conn->connection.endpoint = endpoint;
+    conn->connection.context = context;
     conn->connection.max_send_size = dev->device.max_send_size;
 
     hs = (sock_handshake_t *) (rx->buffer + (uintptr_t) sizeof(sock_header_r_t));

--- a/src/plugins/core/template/core_template_api.c
+++ b/src/plugins/core/template/core_template_api.c
@@ -25,6 +25,7 @@ static int template_create_endpoint(cci_device_t *device,
                                     cci_os_handle_t *fd);
 static int template_destroy_endpoint(cci_endpoint_t *endpoint);
 static int template_accept(union cci_event *event,
+                           void *context,
                            cci_connection_t **connection);
 static int template_reject(union cci_event *event);
 static int template_connect(cci_endpoint_t *endpoint, char *server_uri,
@@ -158,6 +159,7 @@ static int template_destroy_endpoint(cci_endpoint_t *endpoint)
 
 
 static int template_accept(union cci_event *event,
+                           void *context,
                            cci_connection_t **connection)
 {
     printf("In template_accept\n");

--- a/src/plugins/core/verbs/core_verbs_api.c
+++ b/src/plugins/core/verbs/core_verbs_api.c
@@ -41,6 +41,7 @@ static int verbs_create_endpoint(cci_device_t *device,
                                     cci_os_handle_t *fd);
 static int verbs_destroy_endpoint(cci_endpoint_t *endpoint);
 static int verbs_accept(union cci_event *event,
+                        void *context,
                            cci_connection_t **connection);
 static int verbs_reject(union cci_event *event);
 static int verbs_connect(cci_endpoint_t *endpoint, char *server_uri,
@@ -829,6 +830,7 @@ verbs_destroy_endpoint(cci_endpoint_t *endpoint)
 
 static int
 verbs_accept(union cci_event *event,
+             void *context,
                            cci_connection_t **connection)
 {
 	CCI_ENTER;

--- a/src/tests/pingpong.c
+++ b/src/tests/pingpong.c
@@ -312,7 +312,7 @@ do_server()
             accept = 1;
             ready = 1;
             opts = *((options_t *)event->request.data_ptr);
-            ret = cci_accept(event, &connection);
+            ret = cci_accept(event, NULL, &connection);
             check_return("cci_accept", ret, 1);
 
 	    ret = cci_return_event(event);

--- a/src/tests/server.c
+++ b/src/tests/server.c
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
 			/* inspect conn_req_t and decide to accept or reject */
 			if (accept) {
 				/* associate this connect request with this endpoint */
-				cci_accept(event, &connection);
+				cci_accept(event, NULL, &connection);
 
 				/* add new connection to connection list, etc. */
 			} else {

--- a/src/tests/stream.c
+++ b/src/tests/stream.c
@@ -166,7 +166,7 @@ static void poll_events(void)
 		break;
 	case CCI_EVENT_CONNECT_REQUEST:{
 			ready = 1;
-			cci_accept(event, &connection);
+			cci_accept(event, NULL, &connection);
 
 			buffer = calloc(1, connection->max_send_size);
 			if (!buffer) {


### PR DESCRIPTION
This is required to avoid races between threads getting events
from newly accepted connections and threads changing the connection
context right after cci_accept().

Document the new parameter as
 "Cookie to be used to identify the connection in incoming events."
and update the doc of cci_connect() accordingly.

All existing plugins in master branch are updated:
- sock and template build fine
- gni and portals updated but not compiled-tested
- mx and verbs updated but not ready in master branch anyway

All tests updated as well, they build fine.
