### PR TITLE
API: add an endpoint parameter to cci_strerror()

### DIFF
--- a/include/cci.h
+++ b/include/cci.h
@@ -131,6 +131,8 @@ CCI_DECLSPEC int cci_init(uint32_t abi_ver, uint32_t flags, uint32_t * caps);
   CCI_EINVAL).  Error status codes that are unique to CCI are of the
   form CCI_ERR_<foo>.
 
+  These status codes may be stringified with cci_strerror().
+
   \ingroup env
 
   IF YOU ADD TO THESE ENUM CODES, ALSO EXTEND src/api/strerror.c!!
@@ -249,18 +251,6 @@ typedef enum cci_status {
 	CCI_ECONNREFUSED = ECONNREFUSED
 	    /* ...more here, inspired from errno.h... */
 } cci_status_t;
-
-/*!
-  Returns a string corresponding to a CCI status enum.
-
-  \param[in] status: A CCI status enum.
-
-  \return A string when the status is valid.
-  \return NULL if not valid.
-
-  \ingroup env
-*/
-CCI_DECLSPEC const char *cci_strerror(enum cci_status status);
 
 /* ================================================================== */
 /*                                                                    */
@@ -581,6 +571,21 @@ CCI_DECLSPEC int cci_create_endpoint(cci_device_t * device,
   \ingroup endpoints
  */
 CCI_DECLSPEC int cci_destroy_endpoint(cci_endpoint_t * endpoint);
+
+/*!
+  Returns a string corresponding to a CCI status enum.
+
+  \param[in] endpoint: The CCI endpoint that returned this status,
+                       NULL if none applicable.
+  \param[in] status:   A CCI status enum.
+
+  \return A string when the status is valid.
+  \return NULL if not valid.
+
+  \ingroup env
+*/
+CCI_DECLSPEC const char *cci_strerror(cci_endpoint_t *endpoint,
+				      enum cci_status status);
 
 /*====================================================================*/
 /*                                                                    */

--- a/src/api/strerror.c
+++ b/src/api/strerror.c
@@ -16,7 +16,7 @@
 #include "cci.h"
 #include "plugins/core/core.h"
 
-const char *cci_strerror(enum cci_status status)
+const char *cci_strerror(cci_endpoint_t *endpoint, enum cci_status status)
 {
 	switch (status) {
 	case CCI_SUCCESS:
@@ -80,6 +80,6 @@ const char *cci_strerror(enum cci_status status)
 		return "CCI_EADDRNOTAVAIL";
 
 	default:
-		return cci_core->strerror(status);
+		return cci_core->strerror(endpoint, status);
 	}
 }

--- a/src/plugins/core/core.h
+++ b/src/plugins/core/core.h
@@ -32,7 +32,8 @@ BEGIN_C_DECLS
  */
 typedef int (*cci_init_fn_t) (uint32_t abi_ver, uint32_t flags,
 			      uint32_t * caps);
-typedef const char *(*cci_strerror_fn_t) (enum cci_status status);
+typedef const char *(*cci_strerror_fn_t) (cci_endpoint_t * endpoint,
+					  enum cci_status status);
 typedef int (*cci_get_devices_fn_t) (cci_device_t const ***devices);
 typedef int (*cci_free_devices_fn_t) (cci_device_t const **devices);
 typedef int (*cci_create_endpoint_fn_t) (cci_device_t * device,

--- a/src/plugins/core/gni/core_gni_api.c
+++ b/src/plugins/core/gni/core_gni_api.c
@@ -120,7 +120,7 @@ do {                                                                  \
 
 // Local functions
 static int gni_init(uint32_t abi_ver, uint32_t flags, uint32_t * caps);
-static const char *gni_strerror(enum cci_status gRv);
+static const char *gni_strerror(cci_endpoint_t * endpoint, enum cci_status gRv);
 static int gni_get_devices(const cci_device_t *** devices);
 static int gni_free_devices(const cci_device_t ** devices);
 static int gni_create_endpoint(cci_device_t * device,
@@ -1126,7 +1126,7 @@ static int gni_init(uint32_t abi_ver, uint32_t flags, uint32_t * caps)
 	return (cRv);
 }
 
-static const char *gni_strerror(enum cci_status cRv)
+static const char *gni_strerror(cci_endpoint_t * endpoint, enum cci_status cRv)
 {
 
 	debug(CCI_DB_FUNC, "In gni_strerror()");

--- a/src/plugins/core/mx/core_mx_api.c
+++ b/src/plugins/core/mx/core_mx_api.c
@@ -15,7 +15,7 @@
  * Local functions
  */
 static int mx_init(uint32_t abi_ver, uint32_t flags, uint32_t * caps);
-static const char *mx_strerror(enum cci_status status);
+static const char *mx_strerror(cci_endpoint_t * endpoint, enum cci_status status);
 static int mx_get_devices(cci_device_t const ***devices);
 static int mx_free_devices(cci_device_t const **devices);
 static int mx_create_endpoint(cci_device_t * device,
@@ -121,7 +121,7 @@ static int mx_init(uint32_t abi_ver, uint32_t flags, uint32_t * caps)
 	return CCI_SUCCESS;
 }
 
-static const char *mx_strerror(enum cci_status status)
+static const char *mx_strerror(cci_endpoint_t * endpoint, enum cci_status status)
 {
 	printf("In mx_sterrror\n");
 	return NULL;

--- a/src/plugins/core/portals/core_portals_api.c
+++ b/src/plugins/core/portals/core_portals_api.c
@@ -112,7 +112,7 @@ do {                                                        \
  * Local functions
  */
 static int portals_init(uint32_t abi_ver, uint32_t flags, uint32_t * caps);
-static const char *portals_strerror(enum cci_status status);
+static const char *portals_strerror(cci_endpoint_t * endpoint, enum cci_status status);
 static int portals_get_devices(cci_device_t const ***devices);
 static int portals_free_devices(cci_device_t const **devices);
 static int portals_create_endpoint(cci_device_t * device,
@@ -288,7 +288,7 @@ static int portals_init(uint32_t abi_ver, uint32_t flags, uint32_t * caps)
 			break;
 		default:	/* Undocumented portals error */
 			debug(CCI_DB_WARN, "NI: %s",
-			      portals_strerror((enum cci_status)iRC));
+			      portals_strerror(NULL, (enum cci_status)iRC));
 			iRC = CCI_ERROR;
 		}
 		goto out_with_init;
@@ -464,7 +464,7 @@ static int portals_init(uint32_t abi_ver, uint32_t flags, uint32_t * caps)
 	return iRC;
 }
 
-static const char *portals_strerror(enum cci_status status)
+static const char *portals_strerror(cci_endpoint_t * endpoint, enum cci_status status)
 {
 	const char *cp;
 
@@ -2035,8 +2035,8 @@ static int portals_return_event(cci_event_t * event)
 					debug(CCI_DB_WARN,
 					      "%s: post_am_buffer() returned %s",
 					      __func__,
-					      cci_strerror((enum cci_status)
-							   iRC));
+					      cci_strerror(&ep->endpoint,
+							   (enum cci_status)iRC));
 				}
 			}
 			pthread_mutex_unlock(&ep->lock);

--- a/src/plugins/core/sock/core_sock_api.c
+++ b/src/plugins/core/sock/core_sock_api.c
@@ -51,7 +51,8 @@ pthread_t progress_tid, recv_tid;
  * Local functions
  */
 static int sock_init(uint32_t abi_ver, uint32_t flags, uint32_t * caps);
-static const char *sock_strerror(enum cci_status status);
+static const char *sock_strerror(cci_endpoint_t * endpoint,
+				 enum cci_status status);
 static int sock_get_devices(cci_device_t const ***devices);
 static int sock_free_devices(cci_device_t const **devices);
 static int sock_create_endpoint(cci_device_t * device,
@@ -332,7 +333,8 @@ static int sock_init(uint32_t abi_ver, uint32_t flags, uint32_t * caps)
 	return ret;
 }
 
-static const char *sock_strerror(enum cci_status status)
+static const char *sock_strerror(cci_endpoint_t * endpoint,
+				 enum cci_status status)
 {
 	CCI_ENTER;
 
@@ -1766,7 +1768,7 @@ static void sock_progress_pending(cci__dev_t * dev)
 		if (ret != tx->len) {
 			debug((CCI_DB_MSG | CCI_DB_INFO),
 			      "sendto() failed with %s",
-			      cci_strerror((enum cci_status)errno));
+			      cci_strerror(&ep->endpoint, (enum cci_status)errno));
 			continue;
 		}
 	}
@@ -3311,7 +3313,7 @@ static void sock_handle_conn_reply(sock_conn_t * sconn,	/* NULL if rejected */
 				debug((CCI_DB_CONN | CCI_DB_MSG),
 				      "ep %d failed to send conn_ack with %s",
 				      sep->sock,
-				      cci_strerror((enum cci_status)ret));
+				      cci_strerror(&ep->endpoint, (enum cci_status)ret));
 			}
 			pthread_mutex_lock(&ep->lock);
 			TAILQ_INSERT_HEAD(&sep->idle_rxs, rx, entry);
@@ -3443,7 +3445,7 @@ static void sock_handle_conn_reply(sock_conn_t * sconn,	/* NULL if rejected */
 				debug((CCI_DB_CONN | CCI_DB_MSG),
 				      "ep %d failed to send conn_ack with %s",
 				      sep->sock,
-				      cci_strerror((enum cci_status)ret));
+				      cci_strerror(&ep->endpoint, (enum cci_status)ret));
 			}
 		}
 		/* add rx->evt to ep->evts */

--- a/src/plugins/core/template/core_template_api.c
+++ b/src/plugins/core/template/core_template_api.c
@@ -15,7 +15,7 @@
  * Local functions
  */
 static int template_init(uint32_t abi_ver, uint32_t flags, uint32_t * caps);
-static const char *template_strerror(enum cci_status status);
+static const char *template_strerror(cci_endpoint_t * endpoint, enum cci_status status);
 static int template_get_devices(cci_device_t const ***devices);
 static int template_free_devices(cci_device_t const **devices);
 static int template_create_endpoint(cci_device_t * device,
@@ -113,7 +113,7 @@ static int template_init(uint32_t abi_ver, uint32_t flags, uint32_t * caps)
 	return CCI_SUCCESS;
 }
 
-static const char *template_strerror(enum cci_status status)
+static const char *template_strerror(cci_endpoint_t * endpoint, enum cci_status status)
 {
 	printf("In template_sterrror\n");
 	return NULL;

--- a/src/plugins/core/verbs/core_verbs_api.c
+++ b/src/plugins/core/verbs/core_verbs_api.c
@@ -35,7 +35,7 @@ pthread_t progress_tid;
  * Local functions
  */
 static int verbs_init(uint32_t abi_ver, uint32_t flags, uint32_t * caps);
-static const char *verbs_strerror(enum cci_status status);
+static const char *verbs_strerror(cci_endpoint_t * endpoint, enum cci_status status);
 static int verbs_get_devices(cci_device_t const ***devices);
 static int verbs_free_devices(cci_device_t const **devices);
 static int verbs_create_endpoint(cci_device_t * device,
@@ -562,7 +562,7 @@ static int verbs_init(uint32_t abi_ver, uint32_t flags, uint32_t * caps)
 	return ret;
 }
 
-static const char *verbs_strerror(enum cci_status status)
+static const char *verbs_strerror(cci_endpoint_t * endpoint, enum cci_status status)
 {
 	return strerror(status);
 }

--- a/src/tests/client.c
+++ b/src/tests/client.c
@@ -92,16 +92,15 @@ int main(int argc, char *argv[])
 	ret = cci_init(CCI_ABI_VERSION, 0, &caps);
 	if (ret) {
 		fprintf(stderr, "cci_init() failed with %s\n",
-			cci_strerror(ret));
+			cci_strerror(NULL, ret));
 		exit(EXIT_FAILURE);
 	}
-
 
 	/* create an endpoint */
 	ret = cci_create_endpoint(NULL, 0, &endpoint, &fd);
 	if (ret) {
 		fprintf(stderr, "cci_create_endpoint() failed with %s\n",
-			cci_strerror(ret));
+			cci_strerror(NULL, ret));
 		exit(EXIT_FAILURE);
 	}
 
@@ -111,7 +110,7 @@ int main(int argc, char *argv[])
 		    (void *)&timeout, (int)sizeof(timeout));
 	if (ret) {
 		fprintf(stderr, "cci_set_opt() failed with %s\n",
-			cci_strerror(ret));
+			cci_strerror(endpoint, ret));
 		exit(EXIT_FAILURE);
 	}
 
@@ -121,7 +120,7 @@ int main(int argc, char *argv[])
 			CCI_CONN_ATTR_UU, NULL, 0, NULL);
 	if (ret) {
 		fprintf(stderr, "cci_connect() failed with %s\n",
-			cci_strerror(ret));
+			cci_strerror(endpoint, ret));
 		exit(EXIT_FAILURE);
 	}
 
@@ -145,7 +144,7 @@ int main(int argc, char *argv[])
 			       (void *)(uintptr_t) i, 0);
 		if (ret)
 			fprintf(stderr, "send %d failed with %s\n", i,
-				cci_strerror(ret));
+				cci_strerror(endpoint, ret));
 	}
 	while (!done)
 		poll_events(endpoint, &connection, &done);
@@ -153,7 +152,7 @@ int main(int argc, char *argv[])
 	ret = cci_send(connection, "bye", 3, NULL, 0);
 	if (ret)
 		fprintf(stderr, "sending \"bye\" failed with %s\n",
-			cci_strerror(ret));
+			cci_strerror(endpoint, ret));
 
 	while (done != 2)
 		poll_events(endpoint, &connection, &done);
@@ -162,7 +161,7 @@ int main(int argc, char *argv[])
 	ret = cci_destroy_endpoint(endpoint);
 	if (ret) {
 		fprintf(stderr, "cci_destroy_endpoint() failed with %s\n",
-			cci_strerror(ret));
+			cci_strerror(endpoint, ret));
 		exit(EXIT_FAILURE);
 	}
     /* ad cci_finalize() here when available */

--- a/src/tests/init.c
+++ b/src/tests/init.c
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 /*  This is supposed to fail because we will pass value instead of address. */
 	if (CCI_SUCCESS != (rc = cci_init(CCI_ABI_VERSION, 0, 0))) {
 		fprintf(stderr, "Got error back from cci:init: %s\n",
-			cci_strerror(rc));
+			cci_strerror(NULL, rc));
 		return -1;
 	}
 

--- a/src/tests/server.c
+++ b/src/tests/server.c
@@ -27,7 +27,7 @@ int main(int argc, char *argv[])
 	ret = cci_init(CCI_ABI_VERSION, 0, &caps);
 	if (ret) {
 		fprintf(stderr, "cci_init() failed with %s\n",
-			cci_strerror(ret));
+			cci_strerror(NULL, ret));
 		exit(EXIT_FAILURE);
 	}
 
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
 	ret = cci_create_endpoint(NULL, 0, &endpoint, &ep_fd);
 	if (ret) {
 		fprintf(stderr, "cci_create_endpoint() failed with %s\n",
-			cci_strerror(ret));
+			cci_strerror(NULL, ret));
 		exit(EXIT_FAILURE);
 	}
 	printf("opened %s\n", endpoint->name);
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
 		if (ret != 0) {
 			if (ret != CCI_EAGAIN)
 				fprintf(stderr, "cci_get_event() returned %s\n",
-					cci_strerror(ret));
+					cci_strerror(endpoint, ret));
 			continue;
 		}
 		switch (event->type) {
@@ -73,7 +73,7 @@ int main(int argc, char *argv[])
 				    cci_send(connection, buf, offset, NULL, 0);
 				if (ret)
 					fprintf(stderr, "send returned %s\n",
-						cci_strerror(ret));
+						cci_strerror(endpoint, ret));
 				break;
 			}
 		case CCI_EVENT_SEND:

--- a/src/tests/stream.c
+++ b/src/tests/stream.c
@@ -87,7 +87,7 @@ static void poll_events(void)
 	if (ret != 0) {
 		if (ret != CCI_EAGAIN) {
 			fprintf(stderr, "cci_get_event() returned %s\n",
-				cci_strerror(ret));
+				cci_strerror(endpoint, ret));
 		}
 		return;
 	}
@@ -105,7 +105,7 @@ static void poll_events(void)
 				if (ret && 1) {
 					fprintf(stderr,
 						"%s: send returned %s\n",
-						__func__, cci_strerror(ret));
+						__func__, cci_strerror(endpoint, ret));
 				} else
 					send++;
 
@@ -205,7 +205,7 @@ void do_client()
 	ret = cci_connect(endpoint, server_uri, NULL, 0, attr, NULL, 0, NULL);
 	if (ret) {
 		fprintf(stderr, "cci_connect() returned %s\n",
-			cci_strerror(ret));
+			cci_strerror(endpoint, ret));
 		return;
 	}
 
@@ -336,14 +336,14 @@ int main(int argc, char *argv[])
 	ret = cci_init(CCI_ABI_VERSION, 0, &caps);
 	if (ret) {
 		fprintf(stderr, "cci_init() failed with %s\n",
-			cci_strerror(ret));
+			cci_strerror(NULL, ret));
 		exit(EXIT_FAILURE);
 	}
 
 	ret = cci_get_devices((cci_device_t const ***const)&devices);
 	if (ret) {
 		fprintf(stderr, "cci_get_devices() failed with %s\n",
-			cci_strerror(ret));
+			cci_strerror(NULL, ret));
 		exit(EXIT_FAILURE);
 	}
 
@@ -351,7 +351,7 @@ int main(int argc, char *argv[])
 	ret = cci_create_endpoint(NULL, 0, &endpoint, &ep_fd);
 	if (ret) {
 		fprintf(stderr, "cci_create_endpoint() failed with %s\n",
-			cci_strerror(ret));
+			cci_strerror(NULL, ret));
 		exit(EXIT_FAILURE);
 	}
 	printf("opened %s\n", endpoint->name);
@@ -369,7 +369,7 @@ int main(int argc, char *argv[])
 	ret = cci_destroy_endpoint(endpoint);
 	if (ret) {
 		fprintf(stderr, "cci_destroy_endpoint() failed with %s\n",
-			cci_strerror(ret));
+			cci_strerror(NULL, ret));
 		exit(EXIT_FAILURE);
 	}
 	if (buffer)
@@ -377,7 +377,7 @@ int main(int argc, char *argv[])
 	ret = cci_free_devices((cci_device_t const **)devices);
 	if (ret) {
 		fprintf(stderr, "cci_free_devices() failed with %s\n",
-			cci_strerror(ret));
+			cci_strerror(NULL, ret));
 		exit(EXIT_FAILURE);
 	}
 


### PR DESCRIPTION
The endpoint's driver set it, it should handle it.
If no endpoint is relevant, pass NULL instead.
