### PR TITLE
API: app passes cci_opt_t to [get|set]_opt

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -63,16 +63,15 @@ poll_events(cci_endpoint_t * endpoint, cci_connection_t ** connection,
 
 int main(int argc, char *argv[])
 {
-	int done = 0, ret, i = 0, c, len;
+	int done = 0, ret, i = 0, c;
 	uint32_t caps = 0;
 	char *server_uri = NULL;	/* ip://1.2.3.4 */
-	char *uri = NULL;
 	cci_os_handle_t fd;
 	cci_device_t **devices = NULL;
 	cci_endpoint_t *endpoint = NULL;
-	cci_opt_handle_t handle;
+	void * handle;
+	cci_opt_t val;
 	cci_connection_t *connection = NULL;
-	cci_opt_handle_t handle;
 	uint32_t timeout_us = 30 * 1000000;	/* microseconds */
 
 	proc_name = argv[0];
@@ -102,14 +101,14 @@ int main(int argc, char *argv[])
 		exit(EXIT_FAILURE);
 	}
 
-	handle.endpoint = endpoint;
-	ret = cci_get_opt(&handle, CCI_OPT_LEVEL_ENDPOINT,
-			CCI_OPT_ENDPT_URI, (void*) &uri, &len);
+	memset(&val, 0, sizeof(val));
+	handle = (void *)endpoint;
+	ret = cci_get_opt(handle, CCI_OPT_ENDPT_URI, &val);
 	if (ret) {
 		fprintf(stderr, "cci_get_opt() failed with %s\n", cci_strerror(NULL, ret));
 		exit(EXIT_FAILURE);
 	}
-	printf("Opened %s\n", uri);
+	printf("Opened %s\n", val.endpt_uri);
 
 	/* set endpoint tx timeout */
 	handle.endpoint = endpoint;

--- a/examples/server.c
+++ b/examples/server.c
@@ -17,12 +17,12 @@
 
 int main(int argc, char *argv[])
 {
-	int ret, len = 0;;
+	int ret;
 	uint32_t caps = 0;
 	char *uri = NULL;
 	cci_device_t **devices = NULL;
 	cci_endpoint_t *endpoint = NULL;
-	cci_opt_handle_t handle;
+	void * handle;
 	cci_os_handle_t ep_fd;
 	cci_connection_t *connection = NULL;
 
@@ -42,14 +42,14 @@ int main(int argc, char *argv[])
 		exit(EXIT_FAILURE);
 	}
 
-	handle.endpoint = endpoint;
-	ret = cci_get_opt(&handle, CCI_OPT_LEVEL_ENDPOINT,
-			CCI_OPT_ENDPT_URI, (void*)&uri, &len);
+	memset(&val, 0, sizeof(val));
+	handle = endpoint;
+	ret = cci_get_opt(handle, CCI_OPT_ENDPT_URI, &val);
 	if (ret) {
 		fprintf(stderr, "cci_get_opt() failed with %s\n", cci_strerror(NULL, ret));
 		exit(EXIT_FAILURE);
 	}
-	printf("Opened %s\n", uri);
+	printf("Opened %s\n", val.endpt_uri);
 
 	while (1) {
 		char *buffer;

--- a/include/cci.h
+++ b/include/cci.h
@@ -1216,30 +1216,6 @@ CCI_DECLSPEC int cci_return_event(cci_event_t * event);
 /*! \defgroup opts Endpoint / Connection Options */
 
 /*!
-  Handle defining the scope of an option
-
-  \ingroup opts
-*/
-typedef union cci_opt_handle {
-	/*! Endpoint */
-	cci_endpoint_t *endpoint;
-	/*! Connection */
-	cci_connection_t *connection;
-} cci_opt_handle_t;
-
-/*!
-  Level defining the scope of an option
-
-  \ingroup opts
-*/
-typedef enum cci_opt_level {
-	/*! Flag indicating that the union is an endpoint */
-	CCI_OPT_LEVEL_ENDPOINT,
-	/*! Flag indicating that the union is a connection */
-	CCI_OPT_LEVEL_CONNECTION
-} cci_opt_level_t;
-
-/*!
   Name of options
 
   \ingroup opts
@@ -1335,18 +1311,25 @@ typedef struct cci_alignment {
 	uint32_t rma_read_length;	/*!< READ length */
 } cci_alignment_t;
 
+typedef union cci_opt {
+	uint32_t endpt_send_timeout;
+	uint32_t endpt_recv_buf_count;
+	uint32_t endpt_send_buf_count;
+	const char * endpt_uri;
+	uint32_t endpt_keepalive_timeout;
+	cci_alignment_t endpt_rma_align;
+	uint32_t conn_send_timeout;
+} cci_opt_t;
+
 /*!
   Set an endpoint or connection option value.
 
   \param[in] handle Endpoint or connection handle.
-  \param[in] level  Indicates type of handle.
   \param[in] name   Which option to set the value of.
-  \param[in] val    Pointer to the value.
-  \param[in] len    Length of value to be set.
+  \param[in] val    Pointer to a valid cci_opt_t.
 
   \return CCI_SUCCESS   Value successfully set.
-  \return CCI_EINVAL    Handle or val is NULL or len is 0.
-  \return CCI_EINVAL    Level/name mismatch.
+  \return CCI_EINVAL    Handle or val is NULL.
   \return CCI_EINVAL    Trying to set a get-only option.
   \return CCI_ERR_NOT_IMPLEMENTED   Not supported by this driver.
   \return Each driver may have additional error codes.
@@ -1356,28 +1339,23 @@ typedef struct cci_alignment {
 
   \ingroup opts
 */
-CCI_DECLSPEC int cci_set_opt(cci_opt_handle_t * handle, cci_opt_level_t level,
-			     cci_opt_name_t name, const void *val, int len);
+CCI_DECLSPEC int cci_set_opt(void * handle, cci_opt_name_t name, cci_opt_t * val);
 
 /*!
   Get an endpoint or connection option value.
 
   \param[in] handle Endpoint or connection handle.
-  \param[in] level  Indicates type of handle.
   \param[in] name   Which option to set the value of.
-  \param[in] val    Address of the pointer to the value.
-  \param[in] len    Address of the length of value.
+  \param[in] val    Pointer to a valid cci_opt_t.
 
   \return CCI_SUCCESS   Value successfully retrieved.
-  \return CCI_EINVAL    Handle or val is NULL or len is 0.
-  \return CCI_EINVAL    Level/name mismatch.
+  \return CCI_EINVAL    Handle or val is NULL.
   \return CCI_ERR_NOT_IMPLEMENTED   Not supported by this driver.
   \return Each driver may have additional error codes.
 
   \ingroup opts
 */
-CCI_DECLSPEC int cci_get_opt(cci_opt_handle_t * handle, cci_opt_level_t level,
-			     cci_opt_name_t name, void **val, int *len);
+CCI_DECLSPEC int cci_get_opt(void * handle, cci_opt_name_t name, cci_opt_t *val);
 
 /* ================================================================== */
 /*                                                                    */

--- a/src/api/get_opt.c
+++ b/src/api/get_opt.c
@@ -17,115 +17,65 @@
 #include "cci.h"
 #include "plugins/core/core.h"
 
-int cci_get_opt(cci_opt_handle_t * handle, cci_opt_level_t level,
-		cci_opt_name_t name, void **val, int *len)
+int cci_get_opt(void * handle, cci_opt_name_t name, cci_opt_t *val)
 {
 	cci_plugin_core_t * plugin;
 	int ret = CCI_SUCCESS;
 	cci__ep_t *ep = NULL;
 	cci__conn_t *conn = NULL;
 
-	if (NULL == handle || NULL == val || NULL == len) {
+	if (NULL == handle || NULL == val) {
 		return CCI_EINVAL;
 	}
 
 	CCI_ENTER;
 
-	if (CCI_OPT_LEVEL_ENDPOINT == level) {
-		if (handle->endpoint == NULL
-		    || name == CCI_OPT_CONN_SEND_TIMEOUT)
-			return CCI_EINVAL;
-		ep = container_of(handle->endpoint, cci__ep_t, endpoint);
-		plugin = ep->plugin;
-	} else {
-		if (handle->connection == NULL
-		    || name != CCI_OPT_CONN_SEND_TIMEOUT)
-			return CCI_EINVAL;
+	if (CCI_OPT_CONN_SEND_TIMEOUT == name) {
 		conn =
-		    container_of(handle->connection, cci__conn_t, connection);
+		    container_of((cci_connection_t*)handle, cci__conn_t, connection);
 		plugin = conn->plugin;
+	} else {
+		ep = container_of((cci_endpoint_t *)handle, cci__ep_t, endpoint);
+		plugin = ep->plugin;
 	}
 
 	switch (name) {
 	case CCI_OPT_ENDPT_SEND_TIMEOUT:
 		{
-			uint32_t *timeout = calloc(1, sizeof(*timeout));
-			if (!timeout)
-				return CCI_ENOMEM;
-
-			*timeout = ep->tx_timeout;
-			*len = sizeof(*timeout);
-			*val = timeout;
+			val->endpt_send_timeout = ep->tx_timeout;
 			break;
 		}
 	case CCI_OPT_ENDPT_RECV_BUF_COUNT:
 		{
-			uint32_t *count = calloc(1, sizeof(*count));
-			if (!count)
-				return CCI_ENOMEM;
-
-			*count = ep->rx_buf_cnt;
-			*len = sizeof(*count);
-			*val = count;
+			val->endpt_recv_buf_count = ep->rx_buf_cnt;
 			break;
 		}
 	case CCI_OPT_ENDPT_SEND_BUF_COUNT:
 		{
-			uint32_t *count = calloc(1, sizeof(*count));
-			if (!count)
-				return CCI_ENOMEM;
-
-			*count = ep->tx_buf_cnt;
-			*len = sizeof(*count);
-			*val = count;
+			val->endpt_send_buf_count = ep->tx_buf_cnt;
 			break;
 		}
 	case CCI_OPT_ENDPT_KEEPALIVE_TIMEOUT:
 		{
-			uint32_t *timeout = calloc(1, sizeof(*timeout));
-			if (!timeout)
-				return CCI_ENOMEM;
-
-			*timeout = ep->keepalive_timeout;
-			*len = sizeof(*timeout);
-			*val = timeout;
+			val->endpt_keepalive_timeout = ep->keepalive_timeout;
 			break;
 		}
 	case CCI_OPT_ENDPT_URI:
 		{
-			char *uri = strdup(ep->uri);
-			if (!uri)
-				return CCI_ENOMEM;
-
-			*len = strlen(uri);
-			*val = uri;
+			val->endpt_uri = ep->uri;
 			break;
 		}
 	case CCI_OPT_ENDPT_RMA_ALIGN:
 		{
-			int l = sizeof(cci_alignment_t);
-			cci_alignment_t *align = calloc(1, sizeof(l));
-			if (!align)
-				return CCI_ENOMEM;
-
-			memcpy(align, &ep->dev->align, l);
-			*len = l;
-			*val = align;
+			memcpy((void *)&val->endpt_rma_align,
+					(void*)&ep->dev->align, sizeof(ep->dev->align));
 			break;
 		}
 	case CCI_OPT_CONN_SEND_TIMEOUT:
 		{
-			uint32_t *timeout = calloc(1, sizeof(*timeout));
-			if (!timeout)
-				return CCI_ENOMEM;
-
-			*timeout = conn->tx_timeout;
-			*len = sizeof(*timeout);
-			*val = timeout;
+			val->conn_send_timeout = conn->tx_timeout;
 			break;
 		}
-	default:
-		ret = plugin->get_opt(handle, level, name, val, len);
 	}
 
 	CCI_EXIT;

--- a/src/api/set_opt.c
+++ b/src/api/set_opt.c
@@ -17,33 +17,27 @@
 #include "cci.h"
 #include "plugins/core/core.h"
 
-int cci_set_opt(cci_opt_handle_t * handle, cci_opt_level_t level,
-		cci_opt_name_t name, const void *val, int len)
+int cci_set_opt(void * handle, cci_opt_name_t name, cci_opt_t *val)
 {
 	cci_plugin_core_t *plugin;
 	int ret;
 
 	CCI_ENTER;
 
-	if (NULL == handle || NULL == val || len == 0) {
+	if (NULL == handle || NULL == val) {
 		return CCI_EINVAL;
 	}
 
-	if (CCI_OPT_LEVEL_ENDPOINT == level) {
-		cci__ep_t *ep = container_of(handle->endpoint, cci__ep_t, endpoint);
-		if (handle->endpoint == NULL
-		    || name == CCI_OPT_CONN_SEND_TIMEOUT)
-			return CCI_EINVAL;
-		plugin = ep->plugin;
-	} else {
-		cci__conn_t *conn = container_of(handle->connection, cci__conn_t, connection);
-		if (handle->connection == NULL
-		    || name != CCI_OPT_CONN_SEND_TIMEOUT)
-			return CCI_EINVAL;
+	if (CCI_OPT_CONN_SEND_TIMEOUT == name) {
+		cci__conn_t *conn =
+			container_of((cci_connection_t*)handle, cci__conn_t, connection);
 		plugin = conn->plugin;
+	} else {
+		cci__ep_t *ep = container_of((cci_endpoint_t*)handle, cci__ep_t, endpoint);
+		plugin = ep->plugin;
 	}
 
-	ret = plugin->set_opt(handle, level, name, val, len);
+	ret = plugin->set_opt(handle, name, val);
 
 	CCI_EXIT;
 

--- a/src/plugins/core/core.h
+++ b/src/plugins/core/core.h
@@ -53,12 +53,8 @@ typedef int (*cci_connect_fn_t) (cci_endpoint_t * endpoint, const char *server_u
 				 const void *context, int flags,
 				 const struct timeval * timeout);
 typedef int (*cci_disconnect_fn_t) (cci_connection_t * connection);
-typedef int (*cci_set_opt_fn_t) (cci_opt_handle_t * handle,
-				 cci_opt_level_t level,
-				 cci_opt_name_t name, const void *val, int len);
-typedef int (*cci_get_opt_fn_t) (cci_opt_handle_t * handle,
-				 cci_opt_level_t level,
-				 cci_opt_name_t name, void **val, int *len);
+typedef int (*cci_set_opt_fn_t) (void * handle, cci_opt_name_t name, cci_opt_t *val);
+typedef int (*cci_get_opt_fn_t) (void * handle, cci_opt_name_t name, cci_opt_t *val);
 typedef int (*cci_arm_os_handle_fn_t) (cci_endpoint_t * endpoint, int flags);
 typedef int (*cci_get_event_fn_t) (cci_endpoint_t * endpoint,
 				   cci_event_t ** const event);

--- a/src/plugins/core/gni/core_gni_api.c
+++ b/src/plugins/core/gni/core_gni_api.c
@@ -64,12 +64,8 @@ static int gni_connect(cci_endpoint_t * endpoint, const char *server_uri,
 			 cci_conn_attribute_t attribute,
 			 const void *context, int flags, const struct timeval *timeout);
 static int gni_disconnect(cci_connection_t * connection);
-static int gni_set_opt(cci_opt_handle_t * handle,
-			 cci_opt_level_t level,
-			 cci_opt_name_t name, const void *val, int len);
-static int gni_get_opt(cci_opt_handle_t * handle,
-			 cci_opt_level_t level,
-			 cci_opt_name_t name, void **val, int *len);
+static int gni_set_opt(void * handle, cci_opt_name_t name, cci_opt_t *val);
+static int gni_get_opt(void * handle, cci_opt_name_t name, cci_opt_t *val);
 static int gni_arm_os_handle(cci_endpoint_t * endpoint, int flags);
 static int gni_get_event(cci_endpoint_t * endpoint,
 			   cci_event_t ** const event);
@@ -1700,16 +1696,9 @@ static int gni_disconnect(cci_connection_t * connection)
 }
 
 static int
-gni_set_opt(cci_opt_handle_t * handle,
-	      cci_opt_level_t level,
-	      cci_opt_name_t name, const void *val, int len)
+gni_set_opt(void * handle, cci_opt_name_t name, cci_opt_t *val)
 {
 	int ret = CCI_ERR_NOT_IMPLEMENTED;
-	//cci_endpoint_t *endpoint = NULL;
-	//cci__ep_t *ep = NULL;
-	//cci__dev_t *dev = NULL;
-	//gni_ep_t *gep = NULL;
-	//gni_dev_t *gdev = NULL;
 
 	CCI_ENTER;
 
@@ -1717,12 +1706,6 @@ gni_set_opt(cci_opt_handle_t * handle,
 		CCI_EXIT;
 		return CCI_ENODEV;
 	}
-
-	//endpoint = handle->endpoint;
-	//ep = container_of(endpoint, cci__ep_t, endpoint);
-	//gep = ep->priv;
-	//dev = ep->dev;
-	//gdev = dev->priv;
 
 	switch (name) {
 	case CCI_OPT_ENDPT_SEND_TIMEOUT:
@@ -1743,8 +1726,7 @@ gni_set_opt(cci_opt_handle_t * handle,
 }
 
 static int
-gni_get_opt(cci_opt_handle_t * handle,
-	      cci_opt_level_t level, cci_opt_name_t name, void **val, int *len)
+gni_get_opt(void * handle, cci_opt_name_t name, cci_opt_t *val)
 {
 	CCI_ENTER;
 	CCI_EXIT;

--- a/src/plugins/core/mx/core_mx_api.c
+++ b/src/plugins/core/mx/core_mx_api.c
@@ -34,12 +34,8 @@ static int mx_connect(cci_endpoint_t * endpoint, char *server_uri,
 		      cci_conn_attribute_t attribute,
 		      void *context, int flags, struct timeval *timeout);
 static int mx_disconnect(cci_connection_t * connection);
-static int mx_set_opt(cci_opt_handle_t * handle,
-		      cci_opt_level_t level,
-		      cci_opt_name_t name, const void *val, int len);
-static int mx_get_opt(cci_opt_handle_t * handle,
-		      cci_opt_level_t level,
-		      cci_opt_name_t name, void **val, int *len);
+static int mx_set_opt(void * handle, cci_opt_name_t name, cci_opt_t *val);
+static int mx_get_opt(void * handle, cci_opt_name_t name, cci_opt_t *val);
 static int mx_arm_os_handle(cci_endpoint_t * endpoint, int flags);
 static int mx_get_event(cci_endpoint_t * endpoint,
 			cci_event_t ** const event, uint32_t flags);
@@ -193,17 +189,13 @@ static int mx_disconnect(cci_connection_t * connection)
 	return CCI_ERR_NOT_IMPLEMENTED;
 }
 
-static int mx_set_opt(cci_opt_handle_t * handle,
-		      cci_opt_level_t level,
-		      cci_opt_name_t name, const void *val, int len)
+static int mx_set_opt(void * handle, cci_opt_name_t name, cci_opt_t *val)
 {
 	printf("In mx_set_opt\n");
 	return CCI_ERR_NOT_IMPLEMENTED;
 }
 
-static int mx_get_opt(cci_opt_handle_t * handle,
-		      cci_opt_level_t level,
-		      cci_opt_name_t name, void **val, int *len)
+static int mx_get_opt(void * handle, cci_opt_name_t name, cci_opt_t *val)
 {
 	printf("In mx_get_opt\n");
 	return CCI_ERR_NOT_IMPLEMENTED;

--- a/src/plugins/core/template/core_template_api.c
+++ b/src/plugins/core/template/core_template_api.c
@@ -30,12 +30,8 @@ static int template_connect(cci_endpoint_t * endpoint, const char *server_uri,
 			    cci_conn_attribute_t attribute,
 			    const void *context, int flags, const struct timeval *timeout);
 static int template_disconnect(cci_connection_t * connection);
-static int template_set_opt(cci_opt_handle_t * handle,
-			    cci_opt_level_t level,
-			    cci_opt_name_t name, const void *val, int len);
-static int template_get_opt(cci_opt_handle_t * handle,
-			    cci_opt_level_t level,
-			    cci_opt_name_t name, void **val, int *len);
+static int template_set_opt(void * handle, cci_opt_name_t name, cci_opt_t *val);
+static int template_get_opt(void * handle, cci_opt_name_t name, cci_opt_t *val);
 static int template_arm_os_handle(cci_endpoint_t * endpoint, int flags);
 static int template_get_event(cci_endpoint_t * endpoint,
 			      cci_event_t ** event);
@@ -165,17 +161,13 @@ static int template_disconnect(cci_connection_t * connection)
 	return CCI_ERR_NOT_IMPLEMENTED;
 }
 
-static int template_set_opt(cci_opt_handle_t * handle,
-			    cci_opt_level_t level,
-			    cci_opt_name_t name, const void *val, int len)
+static int template_set_opt(void * handle, cci_opt_name_t name, cci_opt_t *val)
 {
 	printf("In template_set_opt\n");
 	return CCI_ERR_NOT_IMPLEMENTED;
 }
 
-static int template_get_opt(cci_opt_handle_t * handle,
-			    cci_opt_level_t level,
-			    cci_opt_name_t name, void **val, int *len)
+static int template_get_opt(void * handle, cci_opt_name_t name, cci_opt_t *val)
 {
 	printf("In template_get_opt\n");
 	return CCI_ERR_NOT_IMPLEMENTED;

--- a/src/tests/cci_info.c
+++ b/src/tests/cci_info.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <inttypes.h>
 
 #include "cci.h"
 
@@ -54,7 +55,7 @@ int main(int argc, char *argv[])
 				 device->pci.dev, device->pci.func);
 
 		if (device->rate)
-			snprintf(rate, sizeof(rate), " %uMBit/s", device->rate / 1000000);
+			snprintf(rate, sizeof(rate), " %"PRIu64"MBit/s", device->rate / 1000000);
 
 		printf("% 2d: %s%s%s%s%s\n",
 		       i, device->name, pcibusid, rate,

--- a/src/tests/pingpong.c
+++ b/src/tests/pingpong.c
@@ -441,9 +441,8 @@ int main(int argc, char *argv[])
 	int ret, c;
 	uint32_t caps = 0;
 	cci_os_handle_t ep_fd;
-	cci_opt_handle_t handle;
-	char *uri = NULL;
-	int len = 0;
+	void * handle;
+	cci_opt_t val;
 
 	name = argv[0];
 
@@ -539,14 +538,14 @@ int main(int argc, char *argv[])
 		exit(EXIT_FAILURE);
 	}
 
-	handle.endpoint = endpoint;
-	ret = cci_get_opt(&handle, CCI_OPT_LEVEL_ENDPOINT,
-			CCI_OPT_ENDPT_URI, (void *)&uri, &len);
+	memset(&val, 0, sizeof(val));
+	handle = (void *)endpoint;
+	ret = cci_get_opt(handle, CCI_OPT_ENDPT_URI, &val);
 	if (ret) {
 		fprintf(stderr, "cci_get_opt() failed with %s\n", cci_strerror(NULL, ret));
 		exit(EXIT_FAILURE);
 	}
-	printf("Opened %s\n", uri);
+	printf("Opened %s\n", val.endpt_uri);
 
 	if (is_server)
 		do_server();

--- a/src/tests/stream.c
+++ b/src/tests/stream.c
@@ -296,9 +296,8 @@ int main(int argc, char *argv[])
 	int ret, c;
 	uint32_t caps = 0;
 	cci_os_handle_t ep_fd;
-	cci_opt_handle_t handle;
-	char *uri = NULL;
-	int len = 0;
+	void * handle;
+	cci_opt_t val;
 
 	name = argv[0];
 
@@ -356,14 +355,14 @@ int main(int argc, char *argv[])
 		exit(EXIT_FAILURE);
 	}
 
-	handle.endpoint = endpoint;
-	ret = cci_get_opt(&handle, CCI_OPT_LEVEL_ENDPOINT,
-			CCI_OPT_ENDPT_URI, (void *)&uri, &len);
+	memset(&val, 0, sizeof(val));
+	handle = (void *)endpoint;
+	ret = cci_get_opt(handle, CCI_OPT_ENDPT_URI, &val);
 	if (ret) {
 		fprintf(stderr, "cci_get_opt() failed with %s\n", cci_strerror(NULL, ret));
 		exit(EXIT_FAILURE);
 	}
-	printf("Opened %s\n", uri);
+	printf("Opened %s\n", val.endpt_uri);
 
 #if MPI_DEBUG
 	MPI_Init(&argc, &argv);


### PR DESCRIPTION
Change cci_opt_handle_t handle to a void *. Drop cci_opt_level_t.
Use the name to determine if the handle is an endpoint or connection.
Create a union of the types that can be passed to these functions.
The app allocates storage for the union.

The downside to this approach is that transports cannot have private
option names.
