### PR TITLE
Add --enable-mutex-errorcheck option

### DIFF
--- a/config/cci.m4
+++ b/config/cci.m4
@@ -100,6 +100,12 @@ AC_DEFUN([CCI_SETUP_CTP],[
           [AC_MSG_WARN([-g has been added to CFLAGS (developer build)])
            CFLAGS="$CFLAGS -g"])
 
+    # Look for mutex-errorcheck
+    AC_ARG_ENABLE(mutex-errorcheck,
+                  AC_HELP_STRING(--mutex-errorcheck, enable mutex error checking),
+                  AC_DEFINE([MUTEX_ERRORCHECK], [1],
+		            [Define to enable mutex error checking]))
+
     # Look for valgrind
     AC_ARG_ENABLE(valgrind,
                   AC_HELP_STRING(--enable-valgrind, enable Valgrind hooks),

--- a/include/cci_lib_types.h
+++ b/include/cci_lib_types.h
@@ -267,5 +267,66 @@ extern int cci__debug;
 #define CCI_VALGRIND_CHECK_WRITABLE(p, s) /* nothing */
 #endif /* !HAVE_DECL_VALGRIND_MAKE_MEM_NOACCESS */
 
+#ifdef MUTEX_ERRORCHECK && MUTEX_ERRORCHECK == 1
+#define CCI_LOCK_INIT(x)			\
+do {						\
+	int ret = 0;				\
+	pthread_mutexattr_t attr;		\
+	ret = pthread_mutexattr_init(&attr);	\
+	if (ret) {				\
+		debug(CCI_DB_ERR, "%s: pthread_mutexattr_init() failed with %s", \
+				__func__, strerror(ret)); \
+		abort();			\
+	}					\
+	ret = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK); \
+	if (ret) {				\
+		debug(CCI_DB_ERR, "%s: pthread_mutexattr_settype() failed with %s", \
+				__func__, strerror(ret)); \
+		abort();			\
+	}					\
+	ret = pthread_mutex_init((x), &attr);	\
+	if (ret) {				\
+		debug(CCI_DB_ERR, "%s: pthread_mutex_init() failed with %s", \
+				__func__, strerror(ret)); \
+		abort();			\
+	}					\
+} while(0)
+#define CCI_LOCK_DESTROY(x)			\
+do {						\
+	int ret = 0;				\
+	ret = pthread_mutex_destroy((x));	\
+	if (ret) {				\
+		debug(CCI_DB_ERR, "%s: pthread_mutex_destroy() failed with %s", \
+				__func__, strerror(ret)); \
+		abort();			\
+	}					\
+} while(0)
+#define CCI_LOCK(x)				\
+do {						\
+	int ret = 0;				\
+	ret = pthread_mutex_lock((x));		\
+	if (ret) {				\
+		debug(CCI_DB_ERR, "%s: pthread_mutex_lock() failed with %s", \
+				__func__, strerror(ret)); \
+		abort();			\
+	}					\
+} while(0)
+#define CCI_UNLOCK(x)				\
+do {						\
+	int ret = 0;				\
+	ret = pthread_mutex_unlock((x));	\
+	if (ret) {				\
+		debug(CCI_DB_ERR, "%s: pthread_mutex_unlock() failed with %s", \
+				__func__, strerror(ret)); \
+		abort();			\
+	}					\
+} while(0)
+#else
+#define CCI_LOCK_INIT(x)	pthread_mutex_init((x), NULL)
+#define CCI_LOCK_DESTROY(x)	pthread_mutex_destroy((x))
+#define CCI_LOCK(x)		pthread_mutex_lock((x))
+#define CCI_UNLOCK(x)		pthread_mutex_unlock((x))
+#endif /* PTHREAD_MUTEX_RECURSIVE */
+
 END_C_DECLS
 #endif /* CCI_LIB_TYPES_H */

--- a/src/api/create_endpoint.c
+++ b/src/api/create_endpoint.c
@@ -27,7 +27,7 @@ int cci_create_endpoint(cci_device_t * device,
 	cci__ep_t *ep;
 	cci__dev_t *dev;
 
-	pthread_mutex_lock(&globals->lock);
+	CCI_LOCK(&globals->lock);
 
 	if (NULL == device) {
 		/* walk list of devs to find default device */
@@ -62,7 +62,7 @@ int cci_create_endpoint(cci_device_t * device,
 	}
 
 	TAILQ_INIT(&ep->evts);
-	pthread_mutex_init(&ep->lock, NULL);
+	CCI_LOCK_INIT(&ep->lock);
 	ep->dev = dev;
 	ep->endpoint.device = &dev->device;
 	*endpoint = &ep->endpoint;
@@ -70,16 +70,16 @@ int cci_create_endpoint(cci_device_t * device,
 	ret = dev->plugin->create_endpoint(device, flags, endpoint, fd);
 
 	ep->plugin = dev->plugin;
-	pthread_mutex_unlock(&globals->lock);
+	CCI_UNLOCK(&globals->lock);
 
-	pthread_mutex_lock(&dev->lock);
+	CCI_LOCK(&dev->lock);
 	/* TODO check dev's state */
 	TAILQ_INSERT_TAIL(&dev->eps, ep, entry);
-	pthread_mutex_unlock(&dev->lock);
+	CCI_UNLOCK(&dev->lock);
 
 	return ret;
 
 out:
-	pthread_mutex_unlock(&globals->lock);
+	CCI_UNLOCK(&globals->lock);
 	return ret;
 }

--- a/src/api/destroy_endpoint.c
+++ b/src/api/destroy_endpoint.c
@@ -29,10 +29,10 @@ int cci_destroy_endpoint(cci_endpoint_t * endpoint)
 	ep = container_of(endpoint, cci__ep_t, endpoint);
 	dev = ep->dev;
 
-	pthread_mutex_lock(&dev->lock);
+	CCI_LOCK(&dev->lock);
 	ep->closing = 1;
 	TAILQ_REMOVE(&dev->eps, ep, entry);
-	pthread_mutex_unlock(&dev->lock);
+	CCI_UNLOCK(&dev->lock);
 
 	/* the transport is responsible for cleaning up ep->priv,
 	 * the evts list, and any cci__conn_t that it is maintaining.


### PR DESCRIPTION
Enabling this option initializes mutexes with a
pthread_mutexattr_type of PTHREAD_MUTEX_ERRORCHECK.
All locks and unlocks will then check the return value
and abort() if there is an error.

We define these macros:

CCI_LOCK_INIT(x)
CCI_LOCK_DESTROY(x)
CCI_LOCK(x)
CCI_UNLOCK(x)

There is no need to initialize and pass a pthread_mutexattr_t
to CCI_LOCK_INIT().

This patch only alters src/api. It does _not_ add this to any
transports.

To use them, simply replace the pthread_mutex_\* with the CCI_*
equivalent. The macros cannot return a value, so do not try to
error check them. If you need error checking, use the configure
option.
