### PR TITLE
API: remove the endpoint context

### DIFF
--- a/include/cci.h
+++ b/include/cci.h
@@ -479,9 +479,6 @@ typedef enum cci_endpoint_flags {
 typedef const struct cci_endpoint {
 	/*! Device that runs this endpoint. */
 	cci_device_t *device;
-
-	/*! Application-provided, private context. */
-	void *context;
 } cci_endpoint_t;
 
 /*! OS-native handles


### PR DESCRIPTION
Based on Scott's email:
 During the call Friday, Patrick asked if the endpoint context was needed.
 I argued that we could have as many as one endpoint per device or one
 endpoint per core.
 Upon further reflection, I agree with Patrick. We need user supplied
 contexts for connections, MSGs, and RMAs, because these are asynchronous
 operations. We need them to determine the owning connection, etc., when
 an event is returned from get_event().
 With endpoints, however, there is no call that returns something and we
 do not know the owning endpoint. For example, get_event() is per endpoint
 and the endpoint is a parameter to the call.
 Given this, I recommend just dropping the void *context from cci_endpoint_t.
