### PR TITLE
API: timeouts are in seconds

### DIFF
--- a/include/cci.h
+++ b/include/cci.h
@@ -739,7 +739,7 @@ CCI_DECLSPEC int cci_reject(cci_event_t *conn_req);
   Multicast connections don't necessarily involve a discrete connection
   server, they may be handled by IGMP or other distributed framework.
 
-  The timeout is expressed in seconds.
+  The timeout is expressed in nanoseconds.
 
   Upon completion, an ...
 
@@ -756,7 +756,8 @@ CCI_DECLSPEC int cci_reject(cci_event_t *conn_req);
                         a connect accepted, rejected, or failed event, and
                         used to identify the connection in incoming events.
   \param[in] flags      Currently unused.
-  \param[in] timeout	NULL means forever.
+  \param[in] timeout	The timeout value in nanoseconds. A value of 0 means
+                        forever.
 
   \return CCI_SUCCESS   The request is buffered and ready to be sent or
                         has been sent.
@@ -769,7 +770,7 @@ CCI_DECLSPEC int cci_reject(cci_event_t *conn_req);
 CCI_DECLSPEC int cci_connect(cci_endpoint_t * endpoint, const char *server_uri,
 			     const void *data_ptr, uint32_t data_len,
 			     cci_conn_attribute_t attribute,
-			     const void *context, int flags, uint32_t timeout);
+			     const void *context, int flags, uint64_t timeout_ns);
 
 /*!
   This constant is the maximum value of data_len passed to cci_connect().
@@ -1259,11 +1260,11 @@ CCI_DECLSPEC int cci_return_event(cci_event_t * event);
 */
 typedef enum cci_opt_name {
 	/*! Default send timeout for all new connections. The value is in
-	   seconds.
+	   nanoseconds.
 
 	   cci_get_opt() and cci_set_opt().
 
-	   The parameter must point to a uint32_t.
+	   The parameter must point to a uint64_t.
 	 */
 	CCI_OPT_ENDPT_SEND_TIMEOUT,
 
@@ -1305,7 +1306,7 @@ typedef enum cci_opt_name {
 	   the connection individually using CCI_OPT_CONN_KEEPALIVE_TIMEOUT or
 	   re-arm all connections with this option.
 
-	   The keepalive timeout is expressed in seconds. The default is 0
+	   The keepalive timeout is expressed in nanoseconds. The default is 0
 	   (i.e. disabled). Using this option enables the same timeout on all
 	   connections, currently opened and those opened in the future.
 
@@ -1315,7 +1316,7 @@ typedef enum cci_opt_name {
 
 	   cci_get_opt() and cci_set_opt().
 
-	   The parameter must point to a uint32_t.
+	   The parameter must point to a uint64_t.
 	 */
 	CCI_OPT_ENDPT_KEEPALIVE_TIMEOUT,
 
@@ -1350,11 +1351,11 @@ typedef enum cci_opt_name {
         */
 	CCI_OPT_ENDPT_RMA_ALIGN,
 
-	/*! Reliable send timeout in seconds.
+	/*! Reliable send timeout in nanoseconds.
 
 	   cci_get_opt() and cci_set_opt().
 
-	   The parameter must point to a uint32_t.
+	   The parameter must point to a uint64_t.
 	 */
 	CCI_OPT_CONN_SEND_TIMEOUT,
 
@@ -1365,11 +1366,11 @@ typedef enum cci_opt_name {
 	   application may use it to re-arm a connection that has raised a
 	   CCI_EVENT_KEEPALIVE_TIMEDOUT, to selectively arm only some
 	   connections, or to set a timeout different from the endpoint's
-	   keepalive timeout period. The value is expressed in seconds.
+	   keepalive timeout period. The value is expressed in nanoseconds.
 
 	   cci_get_opt() and cci_set_opt().
 
-	   The parameter must point to a uint32_t.
+	   The parameter must point to a uint64_t.
 	 */
 	CCI_OPT_CONN_KEEPALIVE_TIMEOUT
 } cci_opt_name_t;


### PR DESCRIPTION
This is for discussion - do not merge!

In this branch, I have converted all mentions of timeouts to use seconds as the units.

It still has a timeout in connect. We could remove it and say that connect uses the value of the endpoint-scoped send timeout (which is 0 (no timeout) by default).
