### PR TITLE
fix for possible rdma_destroy_ep prototype mismatch

### DIFF
--- a/src/plugins/ctp/verbs/ctp_verbs_api.c
+++ b/src/plugins/ctp/verbs/ctp_verbs_api.c
@@ -2982,12 +2982,7 @@ verbs_handle_disconnected(cci__ep_t * ep, struct rdma_cm_event *cm_evt)
 	/* Either way, we got the DISCONNECTED event, it is safe to cleanup
 	 * the QP and CM id.
 	 */
-	ret = rdma_destroy_ep(vconn->id);
-	if (ret == -1) {
-		ret = errno;
-		debug(CCI_DB_WARN, "%s: rdma_destroy_ep() returned %s",
-		      __func__, strerror(ret));
-	}
+	rdma_destroy_ep(vconn->id);
 
 	if (!vconn->cci_disconn) {
 		verbs_destroy_conn(ep, conn);


### PR DESCRIPTION
The `rdma_destroy_ep` function appears to have different prototype definitions in different environments (e.g., http://manpages.ubuntu.com/manpages/wily/man3/rdma_destroy_ep.3.html vs. https://linux.die.net/man/3/rdma_destroy_ep).

On the Cooley system at the ALCF, `rdma_destroy_ep` returns a `void` type, but some CCI code assumes this function returns an int, causing a compile error.

Can we forego the error checking performed on this function call in CCI verbs plugin to make it more portable? It doesn't appear to be doing anything all that important, and there are other places in the code where the return value of `rdma_destroy_ep` is ignored.

If so, this should address this open issue: https://github.com/CCI/cci/issues/45